### PR TITLE
fix scheduler test

### DIFF
--- a/tests/dispatch/test_scheduler.py
+++ b/tests/dispatch/test_scheduler.py
@@ -1,4 +1,5 @@
 import unittest
+from pprint import pprint
 from typing import Any, Callable
 
 from dispatch.coroutine import call, gather
@@ -284,7 +285,7 @@ class TestOneShotScheduler(unittest.TestCase):
 
     def assert_empty_poll(self, output: Output):
         poll = self.assert_poll(output)
-        self.assertEqual(poll.calls, [])
+        self.assertEqual(len(poll.calls), 0)
 
     def assert_poll_call_functions(self, output: Output, expect: list[str]):
         poll = self.assert_poll(output)


### PR DESCRIPTION
Fix for this error, not sure why it didn't occur in CI, I may have a different version of protobuf.
```
================================================ FAILURES ================================================
______________________ TestOneShotScheduler.test_resume_after_gather_one_at_a_time _______________________

self = <tests.dispatch.test_scheduler.TestOneShotScheduler testMethod=test_resume_after_gather_one_at_a_time>

    def test_resume_after_gather_one_at_a_time(self):
        @durable
        async def main():
            return sum(await call_concurrently("a", "b", "c", "d"))

        output = self.start(main)
        calls = self.assert_poll_call_functions(output, ["a", "b", "c", "d"])
        for i, call in enumerate(calls):
            output = self.resume(
                main,
                output,
                [CallResult.from_value(i, correlation_id=call.correlation_id)],
            )
            if i < len(calls) - 1:
>               self.assert_empty_poll(output)

tests/dispatch/test_scheduler.py:159:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/dispatch/test_scheduler.py:288: in assert_empty_poll
    self.assertEqual(poll.calls, [])
E   TypeError: Can only compare repeated composite fields against other repeated composite fields.
```