### PR TITLE
propagate exception traceback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "types-protobuf >= 4.24.0.20240129",
     "grpc-stubs >= 1.53.0.5",
     "http-message-signatures >= 0.4.4",
+    "tblib >= 3.0.0",
 ]
 
 [project.optional-dependencies]
@@ -54,7 +55,6 @@ omit = ["*_pb2_grpc.py", "*_pb2.py", "tests/*", "examples/*", "src/buf/*"]
 
 [tool.mypy]
 exclude = ['^src/buf', '^tests/examples']
-
 
 [tool.pytest.ini_options]
 testpaths = ['tests']

--- a/src/dispatch/scheduler.py
+++ b/src/dispatch/scheduler.py
@@ -1,7 +1,6 @@
 import logging
 import pickle
 import sys
-import traceback
 from dataclasses import dataclass
 from typing import Any, Callable, Protocol, TypeAlias
 

--- a/src/dispatch/scheduler.py
+++ b/src/dispatch/scheduler.py
@@ -1,6 +1,7 @@
 import logging
 import pickle
 import sys
+import traceback
 from dataclasses import dataclass
 from typing import Any, Callable, Protocol, TypeAlias
 
@@ -106,19 +107,19 @@ class Coroutine:
 
     id: CoroutineID
     parent_id: CoroutineID | None
-
     coroutine: DurableCoroutine | DurableGenerator
-
     result: Future | None = None
 
     def run(self) -> Any:
         if self.result is None:
             return self.coroutine.send(None)
-
         assert self.result.ready()
         if (error := self.result.error()) is not None:
             return self.coroutine.throw(error)
         return self.coroutine.send(self.result.value())
+
+    def __str__(self):
+        return self.coroutine.__qualname__
 
     def __repr__(self):
         return f"Coroutine({self.id}, {self.coroutine.__qualname__})"
@@ -254,6 +255,9 @@ class OneShotScheduler:
                     coroutine_id=coroutine.id, value=e.value
                 )
             except Exception as e:
+                logger.exception(
+                    f"@dispatch.coroutine: '{coroutine}' raised an exception"
+                )
                 coroutine_result = CoroutineResult(coroutine_id=coroutine.id, error=e)
 
             # Handle coroutines that return or raise.

--- a/src/dispatch/status.py
+++ b/src/dispatch/status.py
@@ -83,28 +83,23 @@ def status_for_error(error: Exception) -> Status:
     handler = _find_handler(error, _ERROR_TYPES)
     if handler is not None:
         return handler(error)
-
     # If not, resort to standard error categorization.
     #
     # See https://docs.python.org/3/library/exceptions.html
     status = Status.PERMANENT_ERROR
-    try:
-        # Raise the exception and catch it so that the interpreter deals
-        # with exception groups and chaining for us.
-        raise error
-    except IncompatibleStateError:
+    if isinstance(error, IncompatibleStateError):
         status = Status.INCOMPATIBLE_STATE
-    except TimeoutError:
+    elif isinstance(error, TimeoutError):
         status = Status.TIMEOUT
-    except (TypeError, ValueError):
+    elif isinstance(error, (TypeError, ValueError)):
         status = Status.INVALID_ARGUMENT
-    except ConnectionError:
+    elif isinstance(error, ConnectionError):
         status = Status.TCP_ERROR
-    except PermissionError:
+    elif isinstance(error, PermissionError):
         status = Status.PERMISSION_DENIED
-    except FileNotFoundError:
+    elif isinstance(error, FileNotFoundError):
         status = Status.NOT_FOUND
-    except (EOFError, InterruptedError, KeyboardInterrupt, OSError):
+    elif isinstance(error, (EOFError, InterruptedError, KeyboardInterrupt, OSError)):
         # For OSError, we might want to categorize the values of errno to
         # determine whether the error is temporary or permanent.
         #
@@ -112,8 +107,6 @@ def status_for_error(error: Exception) -> Status:
         # be caused by invalid use of syscalls, which are unlikely at higher
         # abstraction levels.
         status = Status.TEMPORARY_ERROR
-    except BaseException:
-        pass
     return status
 
 

--- a/src/dispatch/status.py
+++ b/src/dispatch/status.py
@@ -86,28 +86,28 @@ def status_for_error(error: Exception) -> Status:
     # If not, resort to standard error categorization.
     #
     # See https://docs.python.org/3/library/exceptions.html
-    status = Status.PERMANENT_ERROR
-    if isinstance(error, IncompatibleStateError):
-        status = Status.INCOMPATIBLE_STATE
-    elif isinstance(error, TimeoutError):
-        status = Status.TIMEOUT
-    elif isinstance(error, (TypeError, ValueError)):
-        status = Status.INVALID_ARGUMENT
-    elif isinstance(error, ConnectionError):
-        status = Status.TCP_ERROR
-    elif isinstance(error, PermissionError):
-        status = Status.PERMISSION_DENIED
-    elif isinstance(error, FileNotFoundError):
-        status = Status.NOT_FOUND
-    elif isinstance(error, (EOFError, InterruptedError, KeyboardInterrupt, OSError)):
-        # For OSError, we might want to categorize the values of errno to
-        # determine whether the error is temporary or permanent.
-        #
-        # In general, permanent errors from the OS are rare because they tend to
-        # be caused by invalid use of syscalls, which are unlikely at higher
-        # abstraction levels.
-        status = Status.TEMPORARY_ERROR
-    return status
+    match error:
+        case IncompatibleStateError():
+            return Status.INCOMPATIBLE_STATE
+        case TimeoutError():
+            return Status.TIMEOUT
+        case TypeError() | ValueError():
+            return Status.INVALID_ARGUMENT
+        case ConnectionError():
+            return Status.TCP_ERROR
+        case PermissionError():
+            return Status.PERMISSION_DENIED
+        case FileNotFoundError():
+            return Status.NOT_FOUND
+        case EOFError() | InterruptedError() | KeyboardInterrupt() | OSError():
+            # For OSError, we might want to categorize the values of errnon
+            # to determine whether the error is temporary or permanent.
+            #
+            # In general, permanent errors from the OS are rare because they
+            # tend to be caused by invalid use of syscalls, which are
+            # unlikely at higher abstraction levels.
+            return Status.TEMPORARY_ERROR
+    return Status.PERMANENT_ERROR
 
 
 def status_for_output(output: Any) -> Status:

--- a/tests/dispatch/test_error.py
+++ b/tests/dispatch/test_error.py
@@ -1,0 +1,34 @@
+import traceback
+import unittest
+from pprint import pprint
+
+from dispatch.proto import Error
+
+
+class TestError(unittest.TestCase):
+
+    def test_conversion_between_exception_and_error(self):
+        try:
+            raise ValueError("test")
+        except Exception as e:
+            original_exception = e
+            error = Error.from_exception(e)
+        original_traceback = "".join(traceback.format_exception(original_exception))
+
+        # For some reasons traceback.format_exception does not include the caret
+        # (^) in the original traceback, but it does in the reconstructed one,
+        # so we strip it out to be able to compare the two.
+        reconstructed_exception = error.to_exception()
+        reconstructed_traceback = "".join(
+            traceback.format_exception(reconstructed_exception)
+        )
+        reconstructed_traceback = [
+            s
+            for s in reconstructed_traceback.split("\n")
+            if not s.strip().startswith("^")
+        ]
+        reconstructed_traceback = "\n".join(reconstructed_traceback)
+
+        assert type(reconstructed_exception) is type(original_exception)
+        assert str(reconstructed_exception) == str(original_exception)
+        assert original_traceback == reconstructed_traceback

--- a/tests/dispatch/test_error.py
+++ b/tests/dispatch/test_error.py
@@ -19,12 +19,14 @@ class TestError(unittest.TestCase):
         # (^) in the original traceback, but it does in the reconstructed one,
         # so we strip it out to be able to compare the two.
         def strip_caret(s):
-            return '\n'.join([l for l in s.split('\n') if not l.strip().startswith('^')])
+            return "\n".join(
+                [l for l in s.split("\n") if not l.strip().startswith("^")]
+            )
 
         reconstructed_exception = error.to_exception()
-        reconstructed_traceback = strip_caret("".join(
-            traceback.format_exception(reconstructed_exception)
-        ))
+        reconstructed_traceback = strip_caret(
+            "".join(traceback.format_exception(reconstructed_exception))
+        )
 
         assert type(reconstructed_exception) is type(original_exception)
         assert str(reconstructed_exception) == str(original_exception)
@@ -32,9 +34,9 @@ class TestError(unittest.TestCase):
 
         error2 = Error.from_exception(reconstructed_exception)
         reconstructed_exception2 = error2.to_exception()
-        reconstructed_traceback2 = strip_caret("".join(
-            traceback.format_exception(reconstructed_exception2)
-        ))
+        reconstructed_traceback2 = strip_caret(
+            "".join(traceback.format_exception(reconstructed_exception2))
+        )
 
         assert type(reconstructed_exception2) is type(original_exception)
         assert str(reconstructed_exception2) == str(original_exception)

--- a/tests/dispatch/test_error.py
+++ b/tests/dispatch/test_error.py
@@ -18,17 +18,24 @@ class TestError(unittest.TestCase):
         # For some reasons traceback.format_exception does not include the caret
         # (^) in the original traceback, but it does in the reconstructed one,
         # so we strip it out to be able to compare the two.
+        def strip_caret(s):
+            return '\n'.join([l for l in s.split('\n') if not l.strip().startswith('^')])
+
         reconstructed_exception = error.to_exception()
-        reconstructed_traceback = "".join(
+        reconstructed_traceback = strip_caret("".join(
             traceback.format_exception(reconstructed_exception)
-        )
-        reconstructed_traceback = [
-            s
-            for s in reconstructed_traceback.split("\n")
-            if not s.strip().startswith("^")
-        ]
-        reconstructed_traceback = "\n".join(reconstructed_traceback)
+        ))
 
         assert type(reconstructed_exception) is type(original_exception)
         assert str(reconstructed_exception) == str(original_exception)
         assert original_traceback == reconstructed_traceback
+
+        error2 = Error.from_exception(reconstructed_exception)
+        reconstructed_exception2 = error2.to_exception()
+        reconstructed_traceback2 = strip_caret("".join(
+            traceback.format_exception(reconstructed_exception2)
+        ))
+
+        assert type(reconstructed_exception2) is type(original_exception)
+        assert str(reconstructed_exception2) == str(original_exception)
+        assert original_traceback == reconstructed_traceback2

--- a/tests/dispatch/test_status.py
+++ b/tests/dispatch/test_status.py
@@ -63,6 +63,12 @@ class TestErrorStatus(unittest.TestCase):
         register_error_type(CustomError, handler)
         assert status_for_error(CustomError()) is Status.OK
 
+    def test_status_for_custom_timeout(self):
+        class CustomError(TimeoutError):
+            pass
+
+        assert status_for_error(CustomError()) is Status.TIMEOUT
+
 
 class TestHTTPStatusCodes(unittest.TestCase):
 

--- a/tests/dispatch/test_status.py
+++ b/tests/dispatch/test_status.py
@@ -7,49 +7,49 @@ from dispatch.status import Status, status_for_error
 class TestErrorStatus(unittest.TestCase):
 
     def test_status_for_Exception(self):
-        self.assertEqual(status_for_error(Exception()), Status.PERMANENT_ERROR)
+        assert status_for_error(Exception()) is Status.PERMANENT_ERROR
 
     def test_status_for_ValueError(self):
-        self.assertEqual(status_for_error(ValueError()), Status.INVALID_ARGUMENT)
+        assert status_for_error(ValueError()) is Status.INVALID_ARGUMENT
 
     def test_status_for_TypeError(self):
-        self.assertEqual(status_for_error(TypeError()), Status.INVALID_ARGUMENT)
+        assert status_for_error(TypeError()) is Status.INVALID_ARGUMENT
 
     def test_status_for_KeyError(self):
-        self.assertEqual(status_for_error(KeyError()), Status.PERMANENT_ERROR)
+        assert status_for_error(KeyError()) is Status.PERMANENT_ERROR
 
     def test_status_for_EOFError(self):
-        self.assertEqual(status_for_error(EOFError()), Status.TEMPORARY_ERROR)
+        assert status_for_error(EOFError()) is Status.TEMPORARY_ERROR
 
     def test_status_for_ConnectionError(self):
-        self.assertEqual(status_for_error(ConnectionError()), Status.TCP_ERROR)
+        assert status_for_error(ConnectionError()) is Status.TCP_ERROR
 
     def test_status_for_PermissionError(self):
-        self.assertEqual(status_for_error(PermissionError()), Status.PERMISSION_DENIED)
+        assert status_for_error(PermissionError()) is Status.PERMISSION_DENIED
 
     def test_status_for_FileNotFoundError(self):
-        self.assertEqual(status_for_error(FileNotFoundError()), Status.NOT_FOUND)
+        assert status_for_error(FileNotFoundError()) is Status.NOT_FOUND
 
     def test_status_for_InterruptedError(self):
-        self.assertEqual(status_for_error(InterruptedError()), Status.TEMPORARY_ERROR)
+        assert status_for_error(InterruptedError()) is Status.TEMPORARY_ERROR
 
     def test_status_for_KeyboardInterrupt(self):
-        self.assertEqual(status_for_error(KeyboardInterrupt()), Status.TEMPORARY_ERROR)
+        assert status_for_error(KeyboardInterrupt()) is Status.TEMPORARY_ERROR
 
     def test_status_for_OSError(self):
-        self.assertEqual(status_for_error(OSError()), Status.TEMPORARY_ERROR)
+        assert status_for_error(OSError()) is Status.TEMPORARY_ERROR
 
     def test_status_for_TimeoutError(self):
-        self.assertEqual(status_for_error(TimeoutError()), Status.TIMEOUT)
+        assert status_for_error(TimeoutError()) is Status.TIMEOUT
 
     def test_status_for_BaseException(self):
-        self.assertEqual(status_for_error(BaseException()), Status.PERMANENT_ERROR)
+        assert status_for_error(BaseException()) is Status.PERMANENT_ERROR
 
     def test_status_for_custom_error(self):
         class CustomError(Exception):
             pass
 
-        self.assertEqual(status_for_error(CustomError()), Status.PERMANENT_ERROR)
+        assert status_for_error(CustomError()) is Status.PERMANENT_ERROR
 
     def test_status_for_custom_error_with_handler(self):
         class CustomError(Exception):
@@ -61,58 +61,54 @@ class TestErrorStatus(unittest.TestCase):
         from dispatch.status import register_error_type
 
         register_error_type(CustomError, handler)
-        self.assertEqual(status_for_error(CustomError()), Status.OK)
+        assert status_for_error(CustomError()) is Status.OK
 
 
 class TestHTTPStatusCodes(unittest.TestCase):
 
     def test_http_response_code_status_400(self):
-        self.assertEqual(http_response_code_status(400), Status.INVALID_ARGUMENT)
+        assert http_response_code_status(400) is Status.INVALID_ARGUMENT
 
     def test_http_response_code_status_401(self):
-        self.assertEqual(http_response_code_status(401), Status.UNAUTHENTICATED)
+        assert http_response_code_status(401) is Status.UNAUTHENTICATED
 
     def test_http_response_code_status_403(self):
-        self.assertEqual(http_response_code_status(403), Status.PERMISSION_DENIED)
+        assert http_response_code_status(403) is Status.PERMISSION_DENIED
 
     def test_http_response_code_status_404(self):
-        self.assertEqual(http_response_code_status(404), Status.NOT_FOUND)
+        assert http_response_code_status(404) is Status.NOT_FOUND
 
     def test_http_response_code_status_408(self):
-        self.assertEqual(http_response_code_status(408), Status.TIMEOUT)
+        assert http_response_code_status(408) is Status.TIMEOUT
 
     def test_http_response_code_status_429(self):
-        self.assertEqual(http_response_code_status(429), Status.THROTTLED)
+        assert http_response_code_status(429) is Status.THROTTLED
 
     def test_http_response_code_status_501(self):
-        self.assertEqual(http_response_code_status(501), Status.PERMANENT_ERROR)
+        assert http_response_code_status(501) is Status.PERMANENT_ERROR
 
     def test_http_response_code_status_1xx(self):
         for status in range(100, 200):
-            self.assertEqual(http_response_code_status(100), Status.PERMANENT_ERROR)
+            assert http_response_code_status(100) is Status.PERMANENT_ERROR
 
     def test_http_response_code_status_2xx(self):
         for status in range(200, 300):
-            self.assertEqual(http_response_code_status(200), Status.OK)
+            assert http_response_code_status(200) is Status.OK
 
     def test_http_response_code_status_3xx(self):
         for status in range(300, 400):
-            self.assertEqual(http_response_code_status(300), Status.PERMANENT_ERROR)
+            assert http_response_code_status(300) is Status.PERMANENT_ERROR
 
     def test_http_response_code_status_4xx(self):
         for status in range(400, 500):
             if status not in (400, 401, 403, 404, 408, 429, 501):
-                self.assertEqual(
-                    http_response_code_status(status), Status.PERMANENT_ERROR
-                )
+                assert http_response_code_status(status) is Status.PERMANENT_ERROR
 
     def test_http_response_code_status_5xx(self):
         for status in range(500, 600):
             if status not in (501,):
-                self.assertEqual(
-                    http_response_code_status(status), Status.TEMPORARY_ERROR
-                )
+                assert http_response_code_status(status) is Status.TEMPORARY_ERROR
 
     def test_http_response_code_status_6xx(self):
         for status in range(600, 700):
-            self.assertEqual(http_response_code_status(600), Status.UNSPECIFIED)
+            assert http_response_code_status(600) is Status.UNSPECIFIED


### PR DESCRIPTION
This PR fixes error propagation through the call stack of durable coroutines.

I have added a dependency on the [tblib](https://pypi.org/project/tblib/) package to deal with parsing stack traces and reconstructing traceback objects which is quite tricky to do since these values can only be constructed by the interpreter when raising exceptions ([see](https://python-tblib.readthedocs.io/en/latest/_modules/tblib.html#Traceback.as_traceback)).

Using this code example:
```python
from fastapi import FastAPI
from dispatch.fastapi import Dispatch

app = FastAPI()
dispatch = Dispatch(app)

@dispatch.coroutine()
async def get(something):
    raise ValueError("This is an error")

@dispatch.coroutine()
async def publish():
    return await get.call("this")

@app.get("/")
def root():
    publish.dispatch()
    return "OK"
```

The execution produces these logs:
```
INFO:     Started server process [22270]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
INFO:     127.0.0.1:52112 - "GET / HTTP/1.1" 200 OK
INFO:     127.0.0.1:52119 - "POST /dispatch.sdk.v1.FunctionService/Run HTTP/1.1" 200 OK
@dispatch.coroutine: 'get' raised an exception
Traceback (most recent call last):
  File "/Users/achilleroussel/go/src/github.com/stealthrocket/dispatch-sdk-python/src/dispatch/scheduler.py", line 252, in _run
    coroutine_yield = coroutine.run()
                      ^^^^^^^^^^^^^^^
  File "/Users/achilleroussel/go/src/github.com/stealthrocket/dispatch-sdk-python/src/dispatch/scheduler.py", line 115, in run
    return self.coroutine.send(None)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/achilleroussel/go/src/github.com/stealthrocket/dispatch-sdk-python/src/dispatch/experimental/durable/function.py", line 218, in send
    return self.coroutine.send(send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/achilleroussel/go/src/github.com/stealthrocket/dispatch-sdk-python/main.py", line 14, in get
    raise ValueError("This is an error")
ValueError: This is an error
INFO:     127.0.0.1:52119 - "POST /dispatch.sdk.v1.FunctionService/Run HTTP/1.1" 200 OK
@dispatch.coroutine: 'publish' raised an exception
Traceback (most recent call last):
  File "/Users/achilleroussel/go/src/github.com/stealthrocket/dispatch-sdk-python/src/dispatch/scheduler.py", line 252, in _run
    coroutine_yield = coroutine.run()
                      ^^^^^^^^^^^^^^^
  File "/Users/achilleroussel/go/src/github.com/stealthrocket/dispatch-sdk-python/src/dispatch/scheduler.py", line 118, in run
    return self.coroutine.throw(error)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/achilleroussel/go/src/github.com/stealthrocket/dispatch-sdk-python/src/dispatch/experimental/durable/function.py", line 221, in throw
    return self.coroutine.throw(typ, val, tb)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/achilleroussel/go/src/github.com/stealthrocket/dispatch-sdk-python/main.py", line 19, in publish
    return await get.call("this")
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/achilleroussel/go/src/github.com/stealthrocket/dispatch-sdk-python/src/dispatch/experimental/durable/function.py", line 285, in throw
    return self.generator.throw(typ, val, tb)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/achilleroussel/go/src/github.com/stealthrocket/dispatch-sdk-python/src/dispatch/function.py", line 92, in _call_async
    return await dispatch.coroutine.call(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.7_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/types.py", line 220, in throw
    return self.__wrapped.throw(tp, *rest)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/achilleroussel/go/src/github.com/stealthrocket/dispatch-sdk-python/src/dispatch/experimental/durable/function.py", line 285, in throw
    return self.generator.throw(typ, val, tb)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/achilleroussel/go/src/github.com/stealthrocket/dispatch-sdk-python/src/dispatch/coroutine.py", line 14, in call
    return (yield call)
            ^^^^^^^^^^
  File "/Users/achilleroussel/go/src/github.com/stealthrocket/dispatch-sdk-python/src/dispatch/scheduler.py", line 252, in _run
    coroutine_yield = coroutine.run()
    ^^^^^^^^^^^^^^^^^
  File "/Users/achilleroussel/go/src/github.com/stealthrocket/dispatch-sdk-python/src/dispatch/scheduler.py", line 115, in run
    return self.coroutine.send(None)
    ^^^^^^^^^^^^^^^^^
  File "/Users/achilleroussel/go/src/github.com/stealthrocket/dispatch-sdk-python/src/dispatch/experimental/durable/function.py", line 218, in send
    return self.coroutine.send(send)
    ^^^^^^^^^^^^^^^^^
  File "/Users/achilleroussel/go/src/github.com/stealthrocket/dispatch-sdk-python/main.py", line 14, in get
    raise ValueError("This is an error")
      ^^^^^^^^^^^^^^^^^
ValueError: This is an error
INFO:     127.0.0.1:52119 - "POST /dispatch.sdk.v1.FunctionService/Run HTTP/1.1" 200 OK
```

As we can see here, the original exception traceback is preserved and shown when _re-raising_ the exception in the caller.

Please take a look and let me know if anything should be changed.