### PR TITLE
add slots declarations

### DIFF
--- a/src/dispatch/client.py
+++ b/src/dispatch/client.py
@@ -21,6 +21,8 @@ DEFAULT_API_URL = "https://api.stealthrocket.cloud"
 class Client:
     """Client for the Dispatch API."""
 
+    __slots__ = ("api_url", "api_key", "_stub", "api_key_from")
+
     def __init__(self, api_key: None | str = None, api_url: None | str = None):
         """Create a new Dispatch client.
 

--- a/src/dispatch/coroutine.py
+++ b/src/dispatch/coroutine.py
@@ -23,6 +23,6 @@ def gather(*awaitables: Awaitable[Any]) -> list[Any]:  # type: ignore[misc]
     return (yield Gather(awaitables))
 
 
-@dataclass
+@dataclass(slots=True)
 class Gather:
     awaitables: tuple[Awaitable[Any], ...]

--- a/src/dispatch/experimental/durable/function.py
+++ b/src/dispatch/experimental/durable/function.py
@@ -62,7 +62,15 @@ def durable(fn: Callable) -> Callable:
 class Serializable:
     """A wrapper for a generator or coroutine that makes it serializable."""
 
-    __slots__ = ("g", "registered_fn", "wrapped_coroutine", "args", "kwargs", "__name__", "__qualname__")
+    __slots__ = (
+        "g",
+        "registered_fn",
+        "wrapped_coroutine",
+        "args",
+        "kwargs",
+        "__name__",
+        "__qualname__",
+    )
 
     g: GeneratorType | CoroutineType
     registered_fn: RegisteredFunction

--- a/src/dispatch/experimental/durable/function.py
+++ b/src/dispatch/experimental/durable/function.py
@@ -23,6 +23,8 @@ class DurableFunction:
     """A wrapper for generator functions and async functions that make
     their generator and coroutine instances serializable."""
 
+    __slots__ = ("registered_fn", "__name__", "__qualname__")
+
     def __init__(self, fn: FunctionType):
         self.registered_fn = register_function(fn)
         self.__name__ = fn.__name__
@@ -60,6 +62,8 @@ def durable(fn: Callable) -> Callable:
 class Serializable:
     """A wrapper for a generator or coroutine that makes it serializable."""
 
+    __slots__ = ("g", "registered_fn", "wrapped_coroutine", "args", "kwargs", "__name__", "__qualname__")
+
     g: GeneratorType | CoroutineType
     registered_fn: RegisteredFunction
     wrapped_coroutine: Union["DurableCoroutine", None]
@@ -79,7 +83,6 @@ class Serializable:
         self.wrapped_coroutine = wrapped_coroutine
         self.args = args
         self.kwargs = kwargs
-
         self.__name__ = registered_fn.fn.__name__
         self.__qualname__ = registered_fn.fn.__qualname__
 
@@ -196,6 +199,8 @@ class DurableCoroutine(Serializable, Coroutine[_YieldT, _SendT, _ReturnT]):
     """A wrapper for a coroutine that makes it serializable (can be pickled).
     Instances behave like the coroutines they wrap."""
 
+    __slots__ = ("coroutine",)
+
     def __init__(
         self,
         coroutine: CoroutineType,
@@ -258,6 +263,8 @@ class DurableCoroutine(Serializable, Coroutine[_YieldT, _SendT, _ReturnT]):
 class DurableGenerator(Serializable, Generator[_YieldT, _SendT, _ReturnT]):
     """A wrapper for a generator that makes it serializable (can be pickled).
     Instances behave like the generators they wrap."""
+
+    __slots__ = ("generator",)
 
     def __init__(
         self,

--- a/src/dispatch/experimental/durable/registry.py
+++ b/src/dispatch/experimental/durable/registry.py
@@ -3,12 +3,11 @@ from dataclasses import dataclass
 from types import FunctionType
 
 
-@dataclass
+@dataclass(slots=True)
 class RegisteredFunction:
     """A function that can be referenced in durable state."""
 
     fn: FunctionType
-
     key: str
     filename: str
     lineno: int

--- a/src/dispatch/fastapi.py
+++ b/src/dispatch/fastapi.py
@@ -47,6 +47,8 @@ logger = logging.getLogger(__name__)
 class Dispatch(Registry):
     """A Dispatch programmable endpoint, powered by FastAPI."""
 
+    __slots__ = ()
+
     def __init__(
         self,
         app: fastapi.FastAPI,

--- a/src/dispatch/function.py
+++ b/src/dispatch/function.py
@@ -28,6 +28,8 @@ class Function:
     Dispatch Python SDK.
     """
 
+    __slots__ = ("_endpoint", "_client", "_name", "_primitive_func", "_func", "call")
+
     def __init__(
         self,
         endpoint: str,
@@ -125,6 +127,8 @@ class Function:
 
 class Registry:
     """Registry of local functions."""
+
+    __slots__ = ("_functions", "_endpoint", "_client")
 
     def __init__(self, endpoint: str, client: Client | None):
         """Initialize a local function registry.

--- a/src/dispatch/proto.py
+++ b/src/dispatch/proto.py
@@ -36,6 +36,8 @@ class Input:
     This class is intended to be used as read-only.
     """
 
+    __slots__ = ("_has_input", "_input", "_coroutine_state", "_call_results")
+
     def __init__(self, req: function_pb.RunRequest):
         self._has_input = req.HasField("input")
         if self._has_input:
@@ -115,7 +117,7 @@ class Input:
         )
 
 
-@dataclass
+@dataclass(slots=True)
 class Arguments:
     """A container for positional and keyword arguments."""
 
@@ -123,6 +125,7 @@ class Arguments:
     kwargs: dict[str, Any]
 
 
+@dataclass(slots=True)
 class Output:
     """The output of a primitive function.
 
@@ -131,6 +134,8 @@ class Output:
     methods create an instance of this class. For example Output.value() or
     Output.poll().
     """
+
+    _message: function_pb.RunResponse
 
     def __init__(self, proto: function_pb.RunResponse):
         self._message = proto
@@ -211,7 +216,7 @@ class Output:
 # the current Python process.
 
 
-@dataclass
+@dataclass(slots=True)
 class Call:
     """Instruction to call a function.
 
@@ -234,7 +239,7 @@ class Call:
         )
 
 
-@dataclass
+@dataclass(slots=True)
 class CallResult:
     """Result of a Call."""
 
@@ -276,6 +281,7 @@ class CallResult:
         return CallResult(correlation_id=correlation_id, error=error)
 
 
+@dataclass(slots=True)
 class Error:
     """Error when running a function.
 
@@ -283,11 +289,17 @@ class Error:
     Output.
     """
 
+    status: Status
+    type: str
+    message: str
+    value: Exception | None = None
+    traceback: bytes | None = None
+
     def __init__(
         self,
         status: Status,
-        type: str | None,
-        message: str | None,
+        type: str,
+        message: str,
         value: Exception | None = None,
         traceback: bytes | None = None,
     ):

--- a/src/dispatch/scheduler.py
+++ b/src/dispatch/scheduler.py
@@ -18,7 +18,7 @@ CoroutineID: TypeAlias = int
 CorrelationID: TypeAlias = int
 
 
-@dataclass
+@dataclass(slots=True)
 class CoroutineResult:
     """The result from running a coroutine to completion."""
 
@@ -27,7 +27,7 @@ class CoroutineResult:
     error: Exception | None = None
 
 
-@dataclass
+@dataclass(slots=True)
 class CallResult:
     """The result of an asynchronous function call."""
 
@@ -43,7 +43,7 @@ class Future(Protocol):
     def value(self) -> Any: ...
 
 
-@dataclass
+@dataclass(slots=True)
 class CallFuture:
     """A future result of a dispatch.coroutine.call() operation."""
 
@@ -65,7 +65,7 @@ class CallFuture:
         return self.result.value
 
 
-@dataclass
+@dataclass(slots=True)
 class GatherFuture:
     """A future result of a dispatch.coroutine.gather() operation."""
 
@@ -100,7 +100,7 @@ class GatherFuture:
         return [self.results[id].value for id in self.order]
 
 
-@dataclass
+@dataclass(slots=True)
 class Coroutine:
     """An in-flight coroutine."""
 
@@ -124,15 +124,13 @@ class Coroutine:
         return f"Coroutine({self.id}, {self.coroutine.__qualname__})"
 
 
-@dataclass
+@dataclass(slots=True)
 class State:
     """State of the scheduler and the coroutines it's managing."""
 
     version: str
-
     suspended: dict[CoroutineID, Coroutine]
     ready: list[Coroutine]
-
     next_coroutine_id: int
     next_call_id: int
 
@@ -144,6 +142,8 @@ class OneShotScheduler:
     When all local coroutines are suspended, the scheduler yields to Dispatch to
     take over scheduling asynchronous calls.
     """
+
+    __slots__ = ("entry_point", "version", "poll_max_wait_seconds")
 
     def __init__(
         self, entry_point: Callable, version=sys.version, poll_max_wait_seconds=5

--- a/src/dispatch/signature/key.py
+++ b/src/dispatch/signature/key.py
@@ -48,7 +48,7 @@ def private_key_from_bytes(key: bytes) -> Ed25519PrivateKey:
     return Ed25519PrivateKey.from_private_bytes(key)
 
 
-@dataclass
+@dataclass(slots=True)
 class KeyResolver(HTTPSignatureKeyResolver):
     """KeyResolver provides public and private keys.
 

--- a/src/dispatch/signature/request.py
+++ b/src/dispatch/signature/request.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from http_message_signatures.structures import CaseInsensitiveDict
 
 
-@dataclass
+@dataclass(slots=True)
 class Request:
     """A framework-agnostic representation of an HTTP request."""
 


### PR DESCRIPTION
This will help ensure we are correctly accessing fields that are explicitly declared. It also has memory footprint implications since the interpreter avoids creating a dictionary to maintain the state of the objects.

Where available, I configured the `@dataclass` decorator to automatically generate the `__slots__` attribute. In the few other places where we weren't using `@dataclass`, I declared the slots explicitly.