### PR TITLE
Fix invalid escape sequence in client test regexps

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -26,7 +26,7 @@ class TestClient(unittest.TestCase):
 
         with self.assertRaisesRegex(
             PermissionError,
-            "Dispatch received an invalid authentication token \(check DISPATCH_API_KEY is correct\)",
+            r"Dispatch received an invalid authentication token \(check DISPATCH_API_KEY is correct\)",
         ) as mc:
             client.dispatch([Call(function="my-function", input=42)])
 
@@ -37,7 +37,7 @@ class TestClient(unittest.TestCase):
 
         with self.assertRaisesRegex(
             PermissionError,
-            "Dispatch received an invalid authentication token \(check api_key is correct\)",
+            r"Dispatch received an invalid authentication token \(check api_key is correct\)",
         ) as mc:
             client.dispatch([Call(function="my-function", input=42)])
 


### PR DESCRIPTION
The original error printed by mypy:

```
tests/test_client.py:29: SyntaxWarning: invalid escape sequence '\('
  "Dispatch received an invalid authentication token \(check DISPATCH_API_KEY is correct\)",
tests/test_client.py:40: SyntaxWarning: invalid escape sequence '\('
  "Dispatch received an invalid authentication token \(check api_key is correct\)",
```

Luckily in python all unrecognized escape sequences are left in the string unchanged, so it still worked.