### PR TITLE
Make retry example test more accurate

### DIFF
--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -66,5 +66,5 @@ class TestFullFastapi(unittest.TestCase):
         self.execute()
 
         # Validate results.
-        resp = self.servicer.responses[dispatch_id]
+        resp = self.servicer.response_for(dispatch_id)
         self.assertEqual(any_unpickle(resp.exit.result.output), "Hello world: 52")


### PR DESCRIPTION
Instead of just checking that the function returns, check that it returns an error 5 times and eventually succeeds on the sixth try.

To make this work, the TestServer can now re-enqueue work for the next execute() iteration, and the order of responses returned by the app is preserved.