### PR TITLE
FastAPI: return error responses formatted for the connectrpc protocol

### DIFF
--- a/src/dispatch/signature/digest.py
+++ b/src/dispatch/signature/digest.py
@@ -2,6 +2,7 @@ import hashlib
 import hmac
 
 import http_sfv
+from http_message_signatures import InvalidSignature
 
 
 def generate_content_digest(body: str | bytes) -> str:
@@ -34,7 +35,9 @@ def verify_content_digest(digest_header: str | bytes, body: str | bytes):
         digest = parsed_header["sha-256"].value
         expect_digest = hashlib.sha256(body).digest()
     else:
-        raise ValueError("missing content digest")
+        raise ValueError("missing content digest in http request header")
 
     if not hmac.compare_digest(digest, expect_digest):
-        raise ValueError("unexpected content digest")
+        raise InvalidSignature(
+            "digest of the request body does not match the Content-Digest header"
+        )

--- a/tests/dispatch/signature/test_signature.py
+++ b/tests/dispatch/signature/test_signature.py
@@ -74,7 +74,10 @@ class TestSignature(unittest.TestCase):
     def test_content_digest_invalid(self):
         sign_request(self.request, private_key, datetime.now())
         self.request.body = "foo"
-        with self.assertRaisesRegex(ValueError, "unexpected content digest"):
+        with self.assertRaisesRegex(
+            InvalidSignature,
+            "digest of the request body does not match the Content-Digest header",
+        ):
             verify_request(self.request, public_key, max_age=timedelta(minutes=1))
 
     def test_signature_coverage(self):

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -1,6 +1,7 @@
 import unittest
 
 import fastapi
+import httpx
 from fastapi.testclient import TestClient
 
 from dispatch import Call, Input, Output
@@ -39,8 +40,10 @@ class TestFullFastapi(unittest.TestCase):
             api_url="http://127.0.0.1:10000",
         )
 
-        http_client = TestClient(self.app, base_url="http://dispatch-service")
-        self.app_client = function_service.client(http_client, signing_key=private_key)
+        self.http_client = TestClient(self.app, base_url="http://dispatch-service")
+        self.app_client = function_service.client(
+            self.http_client, signing_key=private_key
+        )
 
         self.server = ServerTest()
         # shortcuts
@@ -68,3 +71,18 @@ class TestFullFastapi(unittest.TestCase):
         # Validate results.
         resp = self.servicer.responses[dispatch_id]
         self.assertEqual(any_unpickle(resp.exit.result.output), "Hello world: 52")
+
+    def test_simple_missing_signature(self):
+        @self.dispatch.function()
+        def my_function(name: str) -> str:
+            return f"Hello world: {name}"
+
+        [dispatch_id] = self.client.dispatch([my_function.build_call(52)])
+
+        self.app_client = function_service.client(self.http_client)  # no signing key
+        try:
+            self.execute()
+        except httpx.HTTPStatusError as e:
+            assert e.response.status_code == 403
+        else:
+            assert False, "Expected HTTPStatusError"

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -84,5 +84,9 @@ class TestFullFastapi(unittest.TestCase):
             self.execute()
         except httpx.HTTPStatusError as e:
             assert e.response.status_code == 403
+            assert e.response.json() == {
+                "code": "permission_denied",
+                "message": 'Expected "Signature-Input" header field to be present',
+            }
         else:
             assert False, "Expected HTTPStatusError"


### PR DESCRIPTION
This PR changes the FastAPI adapter to return error responses in the format expected by the Connect protocol (see https://connectrpc.com/docs/protocol/#error-end-stream).

All errors will now be reported as a http response with a non-200 status code, and a JSON body with this shape:
```json
{
  "code": "...",
  "message": "..."
}
```

Two status codes are now reserved to indicate issues with http request signatures:
- **401** for the `ValueError` raised when the signature uses an unsupported hashing algorithm or when it didn't contain all the expected attributes (these should never occur when connected to the Dispatch platform)
- **403** for any other verification failures related to the signing keys
