### PR TITLE
Remove coroutine decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The SDK allows Python applications to declare *Stateful Functions* that the
 Dispatch scheduler can orchestrate. This is the bare minimum structure used
 to declare stateful functions:
 ```python
-@dispatch.function()
+@dispatch.function
 def action(msg):
     ...
 ```
@@ -94,7 +94,7 @@ import requests
 app = FastAPI()
 dispatch = Dispatch(app)
 
-@dispatch.function()
+@dispatch.function
 def publish(url, payload):
     r = requests.post(url, data=payload)
     r.raise_for_status()

--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ async def transform2(msg):
     ...
 ```
 
+Note that in order to provide durability guarantees, the awaited functions must
+be marked with the `@dispatch.function` decorator.
+
 ## Examples
 
 Check out the [examples](examples/) directory for code samples to help you get

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ This package implements the Dispatch SDK for Python.
   - [Configuration](#configuration)
   - [Integration with FastAPI](#integration-with-fastapi)
   - [Local testing with ngrok](#local-testing-with-ngrok)
+  - [Durable coroutines for Python](#durable-coroutines-for-python)
+- [Examples](#examples)
 - [Contributing](#contributing)
 
 ## What is Dispatch?

--- a/README.md
+++ b/README.md
@@ -148,11 +148,11 @@ export DISPATCH_ENDPOINT_URL="https://f441-2600-1700-2802-e01f-6861-dbc9-d551-ec
 
 ### Durable coroutines for Python
 
-Statefule functions can be turned into durable coroutines by declaring them
+Stateful functions can be turned into durable coroutines by declaring them
 *async*. When doing so, every await point becomes a durable step in the
 function execution: if the awaited operation fails, it is automatically
 retried and the parent function is paused until the result becomes available,
-or a parmanent error is raised.
+or a permanent error is raised.
 
 ```python
 @dispatch.function

--- a/README.md
+++ b/README.md
@@ -148,11 +148,11 @@ export DISPATCH_ENDPOINT_URL="https://f441-2600-1700-2802-e01f-6861-dbc9-d551-ec
 
 ### Durable coroutines for Python
 
-Stateful functions can be turned into durable coroutines by declaring them
-*async*. When doing so, every await point becomes a durable step in the
-function execution: if the awaited operation fails, it is automatically
-retried and the parent function is paused until the result becomes available,
-or a permanent error is raised.
+The `@dispatch.function` decorator can also be applied to Python coroutines
+(a.k.a. *async* functions), in which case each await point on another
+stateful function becomes a durability step in the execution: if the awaited
+operation fails, it is automatically retried and the parent function is paused
+until the result becomes available, or a permanent error is raised.
 
 ```python
 @dispatch.function
@@ -181,8 +181,22 @@ async def transform2(msg):
     ...
 ```
 
-Note that in order to provide durability guarantees, the awaited functions must
-be marked with the `@dispatch.function` decorator.
+This model is composable and can be used to create fan-out/fan-in control flows.
+`gather` can be used to wait on multiple concurrent calls to stateful functions,
+for example:
+
+```python
+from dispatch import gather
+
+@dispatch.function
+async def process(msgs):
+    concurrent_calls = [transform(msg) for msg in msgs]
+    return await gather(*concurrent_calls)
+
+@dispatch.function
+async def transform(msg):
+    ...
+```
 
 ## Examples
 

--- a/examples/auto_retry/app.py
+++ b/examples/auto_retry/app.py
@@ -44,7 +44,7 @@ def third_party_api_call(x):
         return "SUCCESS"
 
 
-# Use the `dispatch.function` decorator to mark a function as durable.
+# Use the `dispatch.function` decorator to declare a stateful function.
 @dispatch.function()
 def some_logic():
     print("Executing some logic")
@@ -56,8 +56,9 @@ def some_logic():
 # This is a normal FastAPI route that handles regular traffic.
 @app.get("/")
 def root():
-    # Use the `dispatch` method to call the durable function. This call is
-    # non-blocking and returns immediately.
+    # Use the `dispatch` method to call the stateful function. This call is
+    # returns immediately after scheduling the function call, which happens in
+    # the background.
     some_logic.dispatch()
-    # Sending an unrelated response immediately.
+    # Sending a response now that the HTTP handler has completed.
     return "OK"

--- a/examples/auto_retry/app.py
+++ b/examples/auto_retry/app.py
@@ -45,7 +45,7 @@ def third_party_api_call(x):
 
 
 # Use the `dispatch.function` decorator to declare a stateful function.
-@dispatch.function()
+@dispatch.function
 def some_logic():
     print("Executing some logic")
     x = rng.randint(0, 5)

--- a/examples/getting_started/app.py
+++ b/examples/getting_started/app.py
@@ -68,7 +68,7 @@ dispatch = Dispatch(app)
 
 
 # Use the `dispatch.function` decorator declare a stateful function.
-@dispatch.function()
+@dispatch.function
 def publish(url, payload):
     r = requests.post(url, data=payload)
     r.raise_for_status()

--- a/examples/getting_started/app.py
+++ b/examples/getting_started/app.py
@@ -67,7 +67,7 @@ app = FastAPI()
 dispatch = Dispatch(app)
 
 
-# Use the `dispatch.function` decorator to mark a function as durable.
+# Use the `dispatch.function` decorator declare a stateful function.
 @dispatch.function()
 def publish(url, payload):
     r = requests.post(url, data=payload)
@@ -77,8 +77,9 @@ def publish(url, payload):
 # This is a normal FastAPI route that handles regular traffic.
 @app.get("/")
 def root():
-    # Use the `dispatch` method to call the durable function. This call is
-    # non-blocking and returns immediately.
+    # Use the `dispatch` method to call the stateful function. This call is
+    # returns immediately after scheduling the function call, which happens in
+    # the background.
     publish.dispatch("https://httpstat.us/200", {"hello": "world"})
-    # Sending an unrelated response immediately.
+    # Sending a response now that the HTTP handler has completed.
     return "OK"

--- a/src/dispatch/experimental/durable/function.py
+++ b/src/dispatch/experimental/durable/function.py
@@ -56,7 +56,7 @@ def durable(fn: Callable) -> Callable:
     elif isinstance(fn, FunctionType):
         return DurableFunction(fn)
     else:
-        raise TypeError("unsupported callable")
+        raise TypeError(f"cannot create a durable function from value of type {fn.__qualname__}")
 
 
 class Serializable:

--- a/src/dispatch/experimental/durable/function.py
+++ b/src/dispatch/experimental/durable/function.py
@@ -56,7 +56,9 @@ def durable(fn: Callable) -> Callable:
     elif isinstance(fn, FunctionType):
         return DurableFunction(fn)
     else:
-        raise TypeError(f"cannot create a durable function from value of type {fn.__qualname__}")
+        raise TypeError(
+            f"cannot create a durable function from value of type {fn.__qualname__}"
+        )
 
 
 class Serializable:

--- a/src/dispatch/function.py
+++ b/src/dispatch/function.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import functools
 import inspect
 import logging
+from functools import wraps
 from types import FunctionType
 from typing import Any, Callable, Dict, TypeAlias
 
@@ -21,6 +21,25 @@ PrimitiveFunctionType: TypeAlias = Callable[[Input], Output]
 and unconditionally returns a dispatch.proto.Output. It must not raise
 exceptions.
 """
+
+
+# https://stackoverflow.com/questions/653368/how-to-create-a-decorator-that-can-be-used-either-with-or-without-parameters
+def decorator(f):
+    """This decorator is intended to declare decorators that can be used with
+    or without parameters. If the decorated function is called with a single
+    callable argument, it is assumed to be a function and the decorator is
+    applied to it. Otherwise, the decorator is called with the arguments
+    provided and the result is returned.
+    """
+
+    @wraps(f)
+    def method(self, *args, **kwargs):
+        if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
+            return f(self, args[0])
+        else:
+            return lambda realf: f(self, realf, *args, **kwargs)
+
+    return method
 
 
 class Function:
@@ -142,32 +161,19 @@ class Registry:
         self._endpoint = endpoint
         self._client = client
 
-    def function(self) -> Callable[[FunctionType], Function]:
+    @decorator
+    def function(self, f: Callable) -> Function:
         """Returns a decorator that registers functions."""
+        return self._register_function(f)
 
-        # Note: the indirection here means that we can add parameters
-        # to the decorator later without breaking existing apps.
-        return self._register_function
-
-    def coroutine(self) -> Callable[[FunctionType], Function | FunctionType]:
-        """Returns a decorator that registers coroutines."""
-
-        # Note: the indirection here means that we can add parameters
-        # to the decorator later without breaking existing apps.
-        return self._register_coroutine
-
-    def primitive_function(self) -> Callable[[PrimitiveFunctionType], Function]:
+    @decorator
+    def primitive_function(self, f: Callable) -> Function:
         """Returns a decorator that registers primitive functions."""
-
-        # Note: the indirection here means that we can add parameters
-        # to the decorator later without breaking existing apps.
-        return self._register_primitive_function
+        return self._register_primitive_function(f)
 
     def _register_function(self, func: Callable) -> Function:
         if inspect.iscoroutinefunction(func):
-            raise TypeError(
-                "async functions must be registered via @dispatch.coroutine"
-            )
+            return self._register_coroutine(func)
 
         logger.info("registering function: %s", func.__qualname__)
 
@@ -175,6 +181,7 @@ class Registry:
         # it's referenced from a @dispatch.coroutine.
         func = durable(func)
 
+        @wraps(func)
         def primitive_func(input: Input) -> Output:
             try:
                 try:
@@ -196,14 +203,11 @@ class Registry:
         return self._register(func, primitive_func)
 
     def _register_coroutine(self, func: Callable) -> Function:
-        if not inspect.iscoroutinefunction(func):
-            raise TypeError(f"{func.__qualname__} must be an async function")
-
         logger.info("registering coroutine: %s", func.__qualname__)
 
         func = durable(func)
 
-        @functools.wraps(func)
+        @wraps(func)
         def primitive_func(input: Input) -> Output:
             return OneShotScheduler(func).run(input)
 

--- a/src/dispatch/function.py
+++ b/src/dispatch/function.py
@@ -47,7 +47,7 @@ class Function:
     Dispatch Python SDK.
     """
 
-    __slots__ = ("_endpoint", "_client", "_name", "_primitive_func", "_func", "_call")
+    __slots__ = ("_endpoint", "_client", "_name", "_primitive_func", "_func")
 
     def __init__(
         self,
@@ -61,13 +61,15 @@ class Function:
         self._client = client
         self._name = name
         self._primitive_func = primitive_func
-        self._func = func
         # FIXME: is there a way to decorate the function at the definition
         #  without making it a class method?
-        self._call = durable(self._call_async)
+        if inspect.iscoroutinefunction(func):
+            self._func = durable(self._call_async)
+        else:
+            self._func = func
 
     def __call__(self, *args, **kwargs):
-        return self._call(*args, **kwargs)
+        return self._func(*args, **kwargs)
 
     def _primitive_call(self, input: Input) -> Output:
         return self._primitive_func(input)

--- a/src/dispatch/function.py
+++ b/src/dispatch/function.py
@@ -36,8 +36,9 @@ def decorator(f):
     def method(self, *args, **kwargs):
         if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
             return f(self, args[0])
-        else:
-            return lambda realf: f(self, realf, *args, **kwargs)
+        def wrapper(func):
+            return f(self, func, *args, **kwargs)
+        return wrapper
 
     return method
 

--- a/src/dispatch/function.py
+++ b/src/dispatch/function.py
@@ -68,7 +68,7 @@ class Function:
         self.call = durable(self._call_async)
 
     def __call__(self, *args, **kwargs):
-        return self._func(*args, **kwargs)
+        return self.call(*args, **kwargs)
 
     def _primitive_call(self, input: Input) -> Output:
         return self._primitive_func(input)
@@ -162,14 +162,14 @@ class Registry:
         self._client = client
 
     @decorator
-    def function(self, f: Callable) -> Function:
+    def function(self, func: Callable) -> Function:
         """Returns a decorator that registers functions."""
-        return self._register_function(f)
+        return self._register_function(func)
 
     @decorator
-    def primitive_function(self, f: Callable) -> Function:
+    def primitive_function(self, func: Callable) -> Function:
         """Returns a decorator that registers primitive functions."""
-        return self._register_primitive_function(f)
+        return self._register_primitive_function(func)
 
     def _register_function(self, func: Callable) -> Function:
         if inspect.iscoroutinefunction(func):

--- a/src/dispatch/function.py
+++ b/src/dispatch/function.py
@@ -36,8 +36,10 @@ def decorator(f):
     def method(self, *args, **kwargs):
         if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
             return f(self, args[0])
+
         def wrapper(func):
             return f(self, func, *args, **kwargs)
+
         return wrapper
 
     return method

--- a/src/dispatch/function.py
+++ b/src/dispatch/function.py
@@ -47,7 +47,7 @@ class Function:
     Dispatch Python SDK.
     """
 
-    __slots__ = ("_endpoint", "_client", "_name", "_primitive_func", "_func", "call")
+    __slots__ = ("_endpoint", "_client", "_name", "_primitive_func", "_func", "_call")
 
     def __init__(
         self,
@@ -62,13 +62,12 @@ class Function:
         self._name = name
         self._primitive_func = primitive_func
         self._func = func
-
         # FIXME: is there a way to decorate the function at the definition
         #  without making it a class method?
-        self.call = durable(self._call_async)
+        self._call = durable(self._call_async)
 
     def __call__(self, *args, **kwargs):
-        return self.call(*args, **kwargs)
+        return self._call(*args, **kwargs)
 
     def _primitive_call(self, input: Input) -> Output:
         return self._primitive_func(input)
@@ -109,7 +108,7 @@ class Function:
         return dispatch_id
 
     async def _call_async(self, *args, **kwargs) -> Any:
-        """Asynchronously call the function from a @dispatch.coroutine."""
+        """Asynchronously call the function from a @dispatch.function."""
         return await dispatch.coroutine.call(
             self.build_call(*args, **kwargs, correlation_id=None)
         )

--- a/src/dispatch/scheduler.py
+++ b/src/dispatch/scheduler.py
@@ -175,7 +175,7 @@ class OneShotScheduler:
 
         main = self.entry_point(*args, **kwargs)
         if not isinstance(main, DurableCoroutine):
-            raise ValueError("entry point is not a @dispatch.coroutine")
+            raise ValueError("entry point is not a @dispatch.function")
 
         return State(
             version=sys.version,
@@ -255,7 +255,7 @@ class OneShotScheduler:
                 )
             except Exception as e:
                 logger.exception(
-                    f"@dispatch.coroutine: '{coroutine}' raised an exception"
+                    f"@dispatch.function: '{coroutine}' raised an exception"
                 )
                 coroutine_result = CoroutineResult(coroutine_id=coroutine.id, error=e)
 
@@ -317,7 +317,7 @@ class OneShotScheduler:
                         g = awaitable.__await__()
                         if not isinstance(g, DurableGenerator):
                             raise ValueError(
-                                "gather awaitable is not a @dispatch.coroutine"
+                                "gather awaitable is not a @dispatch.function"
                             )
                         child_id = state.next_coroutine_id
                         state.next_coroutine_id += 1

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -58,7 +58,7 @@ class TestFullFastapi(unittest.TestCase):
 
     def test_simple_end_to_end(self):
         # The FastAPI server.
-        @self.dispatch.function()
+        @self.dispatch.function
         def my_function(name: str) -> str:
             return f"Hello world: {name}"
 
@@ -73,7 +73,7 @@ class TestFullFastapi(unittest.TestCase):
         self.assertEqual(any_unpickle(resp.exit.result.output), "Hello world: 52")
 
     def test_simple_missing_signature(self):
-        @self.dispatch.function()
+        @self.dispatch.function
         def my_function(name: str) -> str:
             return f"Hello world: {name}"
 


### PR DESCRIPTION
This PR removes the exported `dispatch.coroutine` decorator and integrates the functionality under `dispatch.function`. The intent is to minimize the API footprint and limit the chances of misusing it (e.g., it's impossible to mistakenly pass a Python coroutine to `dispatch.function` and vice versa).

As I was working through this PR, I made two related changes:

- **dispatch.function can now be used without arguments:** this is a common pattern in Python, we were requiring the decorator to be used as a function call (e.g., a call returning a decorator) to future-proof the need to pass arguments to the decorator. I changed the construct so that both syntaxes are supported, so we remain future-proof but can also simplify the declaration when there is no need for arguments.

- **coroutines decorated with dispatch.function can be called:** before the change, calling decorated coroutines would return the underlying generator. Users cannot use this value since they need an event loop to drive the coroutine execution. As I was writing the examples, the presence of repeated `.call` also created a heavy syntax, and writing a simpler `await f(x)` seemed more intuitive. This is a suggestion, and I'm happy to reconsider if we have arguments against it.

Please take a look and let me know if anything should be changed!

Fixes #63 