### PR TITLE
github: update changelog generation rules

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,5 +1,8 @@
 changelog:
   categories:
+    - title: Breaking changes
+      labels:
+        - breaking change
     - title: New features
       labels:
         - enhancement
@@ -12,3 +15,9 @@ changelog:
     - title: Other changes
       labels:
         - "*"
+      exclude:
+        labels:
+          - internal
+    - title: Internal
+      labels:
+        - internal


### PR DESCRIPTION
Include the new labels "internal" and "breaking change".