### PR TITLE
don't crash on missing error traceback

### DIFF
--- a/src/dispatch/proto.py
+++ b/src/dispatch/proto.py
@@ -357,9 +357,11 @@ class Error:
             else:
                 e = cls(self.message)
         if self.traceback is not None:
-            e.__traceback__ = tblib.Traceback.from_string(
-                self.traceback.decode("utf-8"), strict=False
-            ).as_traceback()
+            try:
+                t = self.traceback.decode("utf-8")
+                e.__traceback__ = tblib.Traceback.from_string(t).as_traceback()
+            except Exception:
+                pass  # ignore, better to not have a traceback than to crash
         return e
 
     @classmethod

--- a/tests/dispatch/test_error.py
+++ b/tests/dispatch/test_error.py
@@ -1,8 +1,6 @@
 import traceback
 import unittest
 
-from httpx import HTTPStatusError
-
 from dispatch.proto import Error
 
 
@@ -55,26 +53,3 @@ class TestError(unittest.TestCase):
         reconstructed_exception = error.to_exception()
         assert type(reconstructed_exception) is type(original_exception)
         assert str(reconstructed_exception) == str(original_exception)
-
-    def test_reconstruct_httpx_error(self):
-        req = Request("http://example.com")
-        res = Response(404)
-        try:
-            raise HTTPStatusError("test", request=res, response=res)
-        except Exception as e:
-            original_exception = e
-
-        error = Error.from_exception(original_exception)
-        proto_error = error._as_proto()
-
-        reconstructed_exception = Error._from_proto(proto_error).to_exception()
-        assert type(reconstructed_exception) is type(original_exception)
-        assert str(reconstructed_exception) == str(original_exception)
-
-class Request:
-    def __init__(self, url):
-        self.url = url
-
-class Response:
-    def __init__(self, status_code):
-        self.status_code = status_code

--- a/tests/dispatch/test_error.py
+++ b/tests/dispatch/test_error.py
@@ -1,6 +1,7 @@
 import traceback
 import unittest
-from pprint import pprint
+
+from httpx import HTTPStatusError
 
 from dispatch.proto import Error
 
@@ -54,3 +55,26 @@ class TestError(unittest.TestCase):
         reconstructed_exception = error.to_exception()
         assert type(reconstructed_exception) is type(original_exception)
         assert str(reconstructed_exception) == str(original_exception)
+
+    def test_reconstruct_httpx_error(self):
+        req = Request("http://example.com")
+        res = Response(404)
+        try:
+            raise HTTPStatusError("test", request=res, response=res)
+        except Exception as e:
+            original_exception = e
+
+        error = Error.from_exception(original_exception)
+        proto_error = error._as_proto()
+
+        reconstructed_exception = Error._from_proto(proto_error).to_exception()
+        assert type(reconstructed_exception) is type(original_exception)
+        assert str(reconstructed_exception) == str(original_exception)
+
+class Request:
+    def __init__(self, url):
+        self.url = url
+
+class Response:
+    def __init__(self, status_code):
+        self.status_code = status_code

--- a/tests/dispatch/test_error.py
+++ b/tests/dispatch/test_error.py
@@ -41,3 +41,16 @@ class TestError(unittest.TestCase):
         assert type(reconstructed_exception2) is type(original_exception)
         assert str(reconstructed_exception2) == str(original_exception)
         assert original_traceback == reconstructed_traceback2
+
+    def test_conversion_without_traceback(self):
+        try:
+            raise ValueError("test")
+        except Exception as e:
+            original_exception = e
+
+        error = Error.from_exception(original_exception)
+        error.traceback = ""
+
+        reconstructed_exception = error.to_exception()
+        assert type(reconstructed_exception) is type(original_exception)
+        assert str(reconstructed_exception) == str(original_exception)


### PR DESCRIPTION
Fix for this error:
```
tblib.TracebackParseError: Could not find any frames in ''.
```