### PR TITLE
Handle PollResult errors

### DIFF
--- a/src/dispatch/fastapi.py
+++ b/src/dispatch/fastapi.py
@@ -258,6 +258,8 @@ def _new_app(function_registry: Dispatch, verification_key: Ed25519PublicKey | N
                     )
 
         logger.debug("finished handling run request with status %s", status.name)
-        return fastapi.Response(content=response.SerializeToString(), media_type="application/proto")
+        return fastapi.Response(
+            content=response.SerializeToString(), media_type="application/proto"
+        )
 
     return app

--- a/src/dispatch/fastapi.py
+++ b/src/dispatch/fastapi.py
@@ -258,6 +258,6 @@ def _new_app(function_registry: Dispatch, verification_key: Ed25519PublicKey | N
                     )
 
         logger.debug("finished handling run request with status %s", status.name)
-        return fastapi.Response(content=response.SerializeToString())
+        return fastapi.Response(content=response.SerializeToString(), media_type="application/proto")
 
     return app

--- a/src/dispatch/proto.py
+++ b/src/dispatch/proto.py
@@ -121,14 +121,20 @@ class Input:
 
     @classmethod
     def from_poll_results(
-        cls, function: str, coroutine_state: Any, call_results: list[CallResult]
+        cls,
+        function: str,
+        coroutine_state: Any,
+        call_results: list[CallResult],
+        error: Error | None = None,
     ):
         return Input(
             req=function_pb.RunRequest(
+                function=function,
                 poll_result=poll_pb.PollResult(
                     coroutine_state=coroutine_state,
                     results=[result._as_proto() for result in call_results],
-                )
+                    error=error._as_proto() if error else None,
+                ),
             )
         )
 

--- a/src/dispatch/proto.py
+++ b/src/dispatch/proto.py
@@ -36,7 +36,13 @@ class Input:
     This class is intended to be used as read-only.
     """
 
-    __slots__ = ("_has_input", "_input", "_coroutine_state", "_call_results")
+    __slots__ = (
+        "_has_input",
+        "_input",
+        "_coroutine_state",
+        "_call_results",
+        "_poll_error",
+    )
 
     def __init__(self, req: function_pb.RunRequest):
         self._has_input = req.HasField("input")
@@ -54,6 +60,7 @@ class Input:
             self._call_results = [
                 CallResult._from_proto(r) for r in req.poll_result.results
             ]
+            self._poll_error = Error._from_proto(req.poll_result.error) if req.poll_result.HasField("error") else None
 
     @property
     def is_first_call(self) -> bool:
@@ -84,6 +91,11 @@ class Input:
     def call_results(self) -> list[CallResult]:
         self._assert_resume()
         return self._call_results
+
+    @property
+    def poll_error(self) -> Error | None:
+        self._assert_resume()
+        return self._poll_error
 
     def _assert_first_call(self):
         if self.is_resume:

--- a/src/dispatch/proto.py
+++ b/src/dispatch/proto.py
@@ -60,7 +60,11 @@ class Input:
             self._call_results = [
                 CallResult._from_proto(r) for r in req.poll_result.results
             ]
-            self._poll_error = Error._from_proto(req.poll_result.error) if req.poll_result.HasField("error") else None
+            self._poll_error = (
+                Error._from_proto(req.poll_result.error)
+                if req.poll_result.HasField("error")
+                else None
+            )
 
     @property
     def is_first_call(self) -> bool:

--- a/src/dispatch/scheduler.py
+++ b/src/dispatch/scheduler.py
@@ -208,6 +208,10 @@ class OneShotScheduler:
         else:
             state = self._rebuild_state(input)
 
+            poll_error = input.poll_error
+            if poll_error is not None:
+                raise NotImplementedError
+
             logger.debug("dispatching %d call result(s)", len(input.call_results))
             for cr in input.call_results:
                 assert cr.correlation_id is not None

--- a/src/dispatch/scheduler.py
+++ b/src/dispatch/scheduler.py
@@ -37,7 +37,8 @@ class CallResult:
 
 
 class Future(Protocol):
-    def add(self, result: CallResult | CoroutineResult): ...
+    def add_result(self, result: CallResult | CoroutineResult): ...
+    def add_error(self, error: Exception): ...
     def ready(self) -> bool: ...
     def error(self) -> Exception | None: ...
     def value(self) -> Any: ...
@@ -48,17 +49,25 @@ class CallFuture:
     """A future result of a dispatch.coroutine.call() operation."""
 
     result: CallResult | None = None
+    first_error: Exception | None = None
 
-    def add(self, result: CallResult | CoroutineResult):
+    def add_result(self, result: CallResult | CoroutineResult):
         assert isinstance(result, CallResult)
-        self.result = result
+        if self.result is None:
+            self.result = result
+        if result.error is not None and self.first_error is None:
+            self.first_error = result.error
+
+    def add_error(self, error: Exception):
+        if self.first_error is None:
+            self.first_error = error
 
     def ready(self) -> bool:
-        return self.result is not None
+        return self.first_error is not None or self.result is not None
 
     def error(self) -> Exception | None:
-        assert self.result is not None
-        return self.result.error
+        assert self.ready()
+        return self.first_error
 
     def value(self) -> Any:
         assert self.result is not None
@@ -74,7 +83,7 @@ class GatherFuture:
     results: dict[CoroutineID, CoroutineResult]
     first_error: Exception | None = None
 
-    def add(self, result: CallResult | CoroutineResult):
+    def add_result(self, result: CallResult | CoroutineResult):
         assert isinstance(result, CoroutineResult)
 
         try:
@@ -86,6 +95,10 @@ class GatherFuture:
             self.first_error = result.error
 
         self.results[result.coroutine_id] = result
+
+    def add_error(self, error: Exception):
+        if self.first_error is not None:
+            self.first_error = error
 
     def ready(self) -> bool:
         return self.first_error is not None or len(self.waiting) == 0
@@ -133,6 +146,8 @@ class State:
     ready: list[Coroutine]
     next_coroutine_id: int
     next_call_id: int
+
+    prev_calls: list[Coroutine]
 
 
 class OneShotScheduler:
@@ -183,6 +198,7 @@ class OneShotScheduler:
             ready=[Coroutine(id=0, parent_id=None, coroutine=main)],
             next_coroutine_id=1,
             next_call_id=1,
+            prev_calls=[],
         )
 
     def _rebuild_state(self, input: Input):
@@ -203,6 +219,7 @@ class OneShotScheduler:
             raise IncompatibleStateError from e
 
     def _run(self, input: Input) -> Output:
+
         if input.is_first_call:
             state = self._init_state(input)
         else:
@@ -210,7 +227,18 @@ class OneShotScheduler:
 
             poll_error = input.poll_error
             if poll_error is not None:
-                raise NotImplementedError
+                error = poll_error.to_exception()
+                logger.debug("dispatching poll error: %s", error)
+                for coroutine in state.prev_calls:
+                    future = coroutine.result
+                    assert future is not None
+                    future.add_error(error)
+                    if future.ready() and coroutine.id in state.suspended:
+                        state.ready.append(coroutine)
+                        del state.suspended[coroutine.id]
+                        logger.debug("coroutine %s is now ready", coroutine)
+
+            state.prev_calls = []
 
             logger.debug("dispatching %d call result(s)", len(input.call_results))
             for cr in input.call_results:
@@ -218,8 +246,10 @@ class OneShotScheduler:
                 coroutine_id = correlation_coroutine_id(cr.correlation_id)
                 call_id = correlation_call_id(cr.correlation_id)
 
-                error = cr.error.to_exception() if cr.error is not None else None
-                call_result = CallResult(call_id=call_id, value=cr.output, error=error)
+                call_error = cr.error.to_exception() if cr.error is not None else None
+                call_result = CallResult(
+                    call_id=call_id, value=cr.output, error=call_error
+                )
 
                 try:
                     owner = state.suspended[coroutine_id]
@@ -230,8 +260,8 @@ class OneShotScheduler:
                     continue
 
                 logger.debug("dispatching %s to %s", call_result, owner)
-                future.add(call_result)
-                if future.ready():
+                future.add_result(call_result)
+                if future.ready() and owner.id in state.suspended:
                     state.ready.append(owner)
                     del state.suspended[owner.id]
                     logger.debug("owner %s is now ready", owner)
@@ -288,8 +318,8 @@ class OneShotScheduler:
                 except (KeyError, AssertionError):
                     logger.warning("discarding %s", coroutine_result)
                 else:
-                    future.add(coroutine_result)
-                    if future.ready():
+                    future.add_result(coroutine_result)
+                    if future.ready() and parent.id in state.suspended:
                         state.ready.insert(0, parent)
                         del state.suspended[parent.id]
                         logger.debug("parent %s is now ready", parent)
@@ -312,6 +342,7 @@ class OneShotScheduler:
                     pending_calls.append(call)
                     coroutine.result = CallFuture()
                     state.suspended[coroutine.id] = coroutine
+                    state.prev_calls.append(coroutine)
 
                 case Gather():
                     gather = coroutine_yield

--- a/src/dispatch/sdk/v1/poll_pb2.py
+++ b/src/dispatch/sdk/v1/poll_pb2.py
@@ -17,9 +17,10 @@ from google.protobuf import duration_pb2 as google_dot_protobuf_dot_duration__pb
 
 from buf.validate import validate_pb2 as buf_dot_validate_dot_validate__pb2
 from dispatch.sdk.v1 import call_pb2 as dispatch_dot_sdk_dot_v1_dot_call__pb2
+from dispatch.sdk.v1 import error_pb2 as dispatch_dot_sdk_dot_v1_dot_error__pb2
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b"\n\x1a\x64ispatch/sdk/v1/poll.proto\x12\x0f\x64ispatch.sdk.v1\x1a\x1b\x62uf/validate/validate.proto\x1a\x1a\x64ispatch/sdk/v1/call.proto\x1a\x1egoogle/protobuf/duration.proto\"\xd1\x01\n\x04Poll\x12'\n\x0f\x63oroutine_state\x18\x01 \x01(\x0cR\x0e\x63oroutineState\x12+\n\x05\x63\x61lls\x18\x02 \x03(\x0b\x32\x15.dispatch.sdk.v1.CallR\x05\x63\x61lls\x12\x43\n\x08max_wait\x18\x03 \x01(\x0b\x32\x19.google.protobuf.DurationB\r\xbaH\n\xaa\x01\x04\x32\x02\x08\x01\xc8\x01\x01R\x07maxWait\x12.\n\x0bmax_results\x18\x04 \x01(\x05\x42\r\xbaH\n\x1a\x05\x18\xe8\x07(\x01\xc8\x01\x01R\nmaxResults\"l\n\nPollResult\x12'\n\x0f\x63oroutine_state\x18\x01 \x01(\x0cR\x0e\x63oroutineState\x12\x35\n\x07results\x18\x02 \x03(\x0b\x32\x1b.dispatch.sdk.v1.CallResultR\x07resultsB~\n\x13\x63om.dispatch.sdk.v1B\tPollProtoP\x01\xa2\x02\x03\x44SX\xaa\x02\x0f\x44ispatch.Sdk.V1\xca\x02\x0f\x44ispatch\\Sdk\\V1\xe2\x02\x1b\x44ispatch\\Sdk\\V1\\GPBMetadata\xea\x02\x11\x44ispatch::Sdk::V1b\x06proto3"
+    b"\n\x1a\x64ispatch/sdk/v1/poll.proto\x12\x0f\x64ispatch.sdk.v1\x1a\x1b\x62uf/validate/validate.proto\x1a\x1a\x64ispatch/sdk/v1/call.proto\x1a\x1b\x64ispatch/sdk/v1/error.proto\x1a\x1egoogle/protobuf/duration.proto\"\xd1\x01\n\x04Poll\x12'\n\x0f\x63oroutine_state\x18\x01 \x01(\x0cR\x0e\x63oroutineState\x12+\n\x05\x63\x61lls\x18\x02 \x03(\x0b\x32\x15.dispatch.sdk.v1.CallR\x05\x63\x61lls\x12\x43\n\x08max_wait\x18\x03 \x01(\x0b\x32\x19.google.protobuf.DurationB\r\xbaH\n\xaa\x01\x04\x32\x02\x08\x01\xc8\x01\x01R\x07maxWait\x12.\n\x0bmax_results\x18\x04 \x01(\x05\x42\r\xbaH\n\x1a\x05\x18\xe8\x07(\x01\xc8\x01\x01R\nmaxResults\"\x9a\x01\n\nPollResult\x12'\n\x0f\x63oroutine_state\x18\x01 \x01(\x0cR\x0e\x63oroutineState\x12\x35\n\x07results\x18\x02 \x03(\x0b\x32\x1b.dispatch.sdk.v1.CallResultR\x07results\x12,\n\x05\x65rror\x18\x03 \x01(\x0b\x32\x16.dispatch.sdk.v1.ErrorR\x05\x65rrorB~\n\x13\x63om.dispatch.sdk.v1B\tPollProtoP\x01\xa2\x02\x03\x44SX\xaa\x02\x0f\x44ispatch.Sdk.V1\xca\x02\x0f\x44ispatch\\Sdk\\V1\xe2\x02\x1b\x44ispatch\\Sdk\\V1\\GPBMetadata\xea\x02\x11\x44ispatch::Sdk::V1b\x06proto3"
 )
 
 _globals = globals()
@@ -40,8 +41,8 @@ if _descriptor._USE_C_DESCRIPTORS == False:
     _globals["_POLL"].fields_by_name[
         "max_results"
     ]._serialized_options = b"\272H\n\032\005\030\350\007(\001\310\001\001"
-    _globals["_POLL"]._serialized_start = 137
-    _globals["_POLL"]._serialized_end = 346
-    _globals["_POLLRESULT"]._serialized_start = 348
-    _globals["_POLLRESULT"]._serialized_end = 456
+    _globals["_POLL"]._serialized_start = 166
+    _globals["_POLL"]._serialized_end = 375
+    _globals["_POLLRESULT"]._serialized_start = 378
+    _globals["_POLLRESULT"]._serialized_end = 532
 # @@protoc_insertion_point(module_scope)

--- a/src/dispatch/sdk/v1/poll_pb2.pyi
+++ b/src/dispatch/sdk/v1/poll_pb2.pyi
@@ -11,6 +11,7 @@ from google.protobuf.internal import containers as _containers
 
 from buf.validate import validate_pb2 as _validate_pb2
 from dispatch.sdk.v1 import call_pb2 as _call_pb2
+from dispatch.sdk.v1 import error_pb2 as _error_pb2
 
 DESCRIPTOR: _descriptor.FileDescriptor
 
@@ -33,13 +34,16 @@ class Poll(_message.Message):
     ) -> None: ...
 
 class PollResult(_message.Message):
-    __slots__ = ("coroutine_state", "results")
+    __slots__ = ("coroutine_state", "results", "error")
     COROUTINE_STATE_FIELD_NUMBER: _ClassVar[int]
     RESULTS_FIELD_NUMBER: _ClassVar[int]
+    ERROR_FIELD_NUMBER: _ClassVar[int]
     coroutine_state: bytes
     results: _containers.RepeatedCompositeFieldContainer[_call_pb2.CallResult]
+    error: _error_pb2.Error
     def __init__(
         self,
         coroutine_state: _Optional[bytes] = ...,
         results: _Optional[_Iterable[_Union[_call_pb2.CallResult, _Mapping]]] = ...,
+        error: _Optional[_Union[_error_pb2.Error, _Mapping]] = ...,
     ) -> None: ...


### PR DESCRIPTION
This fixes https://github.com/stealthrocket/dispatch-sdk-python/issues/87.

When there's an error polling, we now raise an error in the coroutines that are waiting on a call that was made before the previous yield. Other in-flight calls are not affected.