### PR TITLE
Use min_results when polling

### DIFF
--- a/src/dispatch/proto.py
+++ b/src/dispatch/proto.py
@@ -202,7 +202,8 @@ class Output:
         cls,
         state: Any,
         calls: None | list[Call] = None,
-        max_results: int = 1,
+        min_results: int = 1,
+        max_results: int = 10,
         max_wait_seconds: int | None = None,
     ) -> Output:
         """Suspend the function with a set of Calls, instructing the
@@ -216,6 +217,7 @@ class Output:
         )
         poll = poll_pb.Poll(
             coroutine_state=state_bytes,
+            min_results=min_results,
             max_results=max_results,
             max_wait=max_wait,
         )

--- a/src/dispatch/scheduler.py
+++ b/src/dispatch/scheduler.py
@@ -175,7 +175,7 @@ class OneShotScheduler:
         version: str = sys.version,
         poll_min_results: int = 1,
         poll_max_results: int = 10,
-        poll_max_wait_seconds: int = 60,
+        poll_max_wait_seconds: int | None = None,
     ):
         """Initialize the scheduler.
 
@@ -195,7 +195,7 @@ class OneShotScheduler:
                 per request.
 
             poll_max_wait_seconds: Maximum amount of time to suspend coroutines
-                while waiting for call results.
+                while waiting for call results. Optional.
         """
         self.entry_point = entry_point
         self.version = version

--- a/src/dispatch/sdk/v1/poll_pb2.py
+++ b/src/dispatch/sdk/v1/poll_pb2.py
@@ -20,7 +20,7 @@ from dispatch.sdk.v1 import call_pb2 as dispatch_dot_sdk_dot_v1_dot_call__pb2
 from dispatch.sdk.v1 import error_pb2 as dispatch_dot_sdk_dot_v1_dot_error__pb2
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b"\n\x1a\x64ispatch/sdk/v1/poll.proto\x12\x0f\x64ispatch.sdk.v1\x1a\x1b\x62uf/validate/validate.proto\x1a\x1a\x64ispatch/sdk/v1/call.proto\x1a\x1b\x64ispatch/sdk/v1/error.proto\x1a\x1egoogle/protobuf/duration.proto\"\xd1\x01\n\x04Poll\x12'\n\x0f\x63oroutine_state\x18\x01 \x01(\x0cR\x0e\x63oroutineState\x12+\n\x05\x63\x61lls\x18\x02 \x03(\x0b\x32\x15.dispatch.sdk.v1.CallR\x05\x63\x61lls\x12\x43\n\x08max_wait\x18\x03 \x01(\x0b\x32\x19.google.protobuf.DurationB\r\xbaH\n\xaa\x01\x04\x32\x02\x08\x01\xc8\x01\x01R\x07maxWait\x12.\n\x0bmax_results\x18\x04 \x01(\x05\x42\r\xbaH\n\x1a\x05\x18\xe8\x07(\x01\xc8\x01\x01R\nmaxResults\"\x9a\x01\n\nPollResult\x12'\n\x0f\x63oroutine_state\x18\x01 \x01(\x0cR\x0e\x63oroutineState\x12\x35\n\x07results\x18\x02 \x03(\x0b\x32\x1b.dispatch.sdk.v1.CallResultR\x07results\x12,\n\x05\x65rror\x18\x03 \x01(\x0b\x32\x16.dispatch.sdk.v1.ErrorR\x05\x65rrorB~\n\x13\x63om.dispatch.sdk.v1B\tPollProtoP\x01\xa2\x02\x03\x44SX\xaa\x02\x0f\x44ispatch.Sdk.V1\xca\x02\x0f\x44ispatch\\Sdk\\V1\xe2\x02\x1b\x44ispatch\\Sdk\\V1\\GPBMetadata\xea\x02\x11\x44ispatch::Sdk::V1b\x06proto3"
+    b"\n\x1a\x64ispatch/sdk/v1/poll.proto\x12\x0f\x64ispatch.sdk.v1\x1a\x1b\x62uf/validate/validate.proto\x1a\x1a\x64ispatch/sdk/v1/call.proto\x1a\x1b\x64ispatch/sdk/v1/error.proto\x1a\x1egoogle/protobuf/duration.proto\"\x81\x02\n\x04Poll\x12'\n\x0f\x63oroutine_state\x18\x01 \x01(\x0cR\x0e\x63oroutineState\x12+\n\x05\x63\x61lls\x18\x02 \x03(\x0b\x32\x15.dispatch.sdk.v1.CallR\x05\x63\x61lls\x12\x43\n\x08max_wait\x18\x03 \x01(\x0b\x32\x19.google.protobuf.DurationB\r\xbaH\n\xaa\x01\x04\x32\x02\x08\x01\xc8\x01\x01R\x07maxWait\x12.\n\x0bmax_results\x18\x04 \x01(\x05\x42\r\xbaH\n\x1a\x05\x18\xe8\x07(\x01\xc8\x01\x01R\nmaxResults\x12.\n\x0bmin_results\x18\x05 \x01(\x05\x42\r\xbaH\n\x1a\x05\x18\xe8\x07(\x01\xc8\x01\x01R\nminResults\"\x9a\x01\n\nPollResult\x12'\n\x0f\x63oroutine_state\x18\x01 \x01(\x0cR\x0e\x63oroutineState\x12\x35\n\x07results\x18\x02 \x03(\x0b\x32\x1b.dispatch.sdk.v1.CallResultR\x07results\x12,\n\x05\x65rror\x18\x03 \x01(\x0b\x32\x16.dispatch.sdk.v1.ErrorR\x05\x65rrorB~\n\x13\x63om.dispatch.sdk.v1B\tPollProtoP\x01\xa2\x02\x03\x44SX\xaa\x02\x0f\x44ispatch.Sdk.V1\xca\x02\x0f\x44ispatch\\Sdk\\V1\xe2\x02\x1b\x44ispatch\\Sdk\\V1\\GPBMetadata\xea\x02\x11\x44ispatch::Sdk::V1b\x06proto3"
 )
 
 _globals = globals()
@@ -41,8 +41,12 @@ if _descriptor._USE_C_DESCRIPTORS == False:
     _globals["_POLL"].fields_by_name[
         "max_results"
     ]._serialized_options = b"\272H\n\032\005\030\350\007(\001\310\001\001"
+    _globals["_POLL"].fields_by_name["min_results"]._options = None
+    _globals["_POLL"].fields_by_name[
+        "min_results"
+    ]._serialized_options = b"\272H\n\032\005\030\350\007(\001\310\001\001"
     _globals["_POLL"]._serialized_start = 166
-    _globals["_POLL"]._serialized_end = 375
-    _globals["_POLLRESULT"]._serialized_start = 378
-    _globals["_POLLRESULT"]._serialized_end = 532
+    _globals["_POLL"]._serialized_end = 423
+    _globals["_POLLRESULT"]._serialized_start = 426
+    _globals["_POLLRESULT"]._serialized_end = 580
 # @@protoc_insertion_point(module_scope)

--- a/src/dispatch/sdk/v1/poll_pb2.pyi
+++ b/src/dispatch/sdk/v1/poll_pb2.pyi
@@ -16,21 +16,24 @@ from dispatch.sdk.v1 import error_pb2 as _error_pb2
 DESCRIPTOR: _descriptor.FileDescriptor
 
 class Poll(_message.Message):
-    __slots__ = ("coroutine_state", "calls", "max_wait", "max_results")
+    __slots__ = ("coroutine_state", "calls", "max_wait", "max_results", "min_results")
     COROUTINE_STATE_FIELD_NUMBER: _ClassVar[int]
     CALLS_FIELD_NUMBER: _ClassVar[int]
     MAX_WAIT_FIELD_NUMBER: _ClassVar[int]
     MAX_RESULTS_FIELD_NUMBER: _ClassVar[int]
+    MIN_RESULTS_FIELD_NUMBER: _ClassVar[int]
     coroutine_state: bytes
     calls: _containers.RepeatedCompositeFieldContainer[_call_pb2.Call]
     max_wait: _duration_pb2.Duration
     max_results: int
+    min_results: int
     def __init__(
         self,
         coroutine_state: _Optional[bytes] = ...,
         calls: _Optional[_Iterable[_Union[_call_pb2.Call, _Mapping]]] = ...,
         max_wait: _Optional[_Union[_duration_pb2.Duration, _Mapping]] = ...,
         max_results: _Optional[int] = ...,
+        min_results: _Optional[int] = ...,
     ) -> None: ...
 
 class PollResult(_message.Message):

--- a/src/dispatch/test/server.py
+++ b/src/dispatch/test/server.py
@@ -19,8 +19,8 @@ class DispatchServer:
     def __init__(
         self,
         service: dispatch_grpc.DispatchServiceServicer,
-        hostname="127.0.0.1",
-        port=0,
+        hostname: str = "127.0.0.1",
+        port: int = 0,
     ):
         self._thread_pool = concurrent.futures.thread.ThreadPoolExecutor()
         self._server = grpc.server(self._thread_pool)

--- a/src/dispatch/test/service.py
+++ b/src/dispatch/test/service.py
@@ -275,7 +275,7 @@ class Poller:
     function: str
 
     coroutine_state: bytes
-    # TODO: support max_wait/max_results
+    # TODO: support max_wait/min_results/max_results
 
     waiting: dict[DispatchID, call_pb.Call]
     results: dict[DispatchID, call_pb.CallResult]


### PR DESCRIPTION
The local coroutine scheduler (#52) now uses the `min_results` setting from https://github.com/stealthrocket/dispatch-sdk-protobuf/pull/14 to improve polling latency & throughput.

Most users should find the default polling configuration satisfactory. Power users can instantiate their own scheduler and play around with the settings to tune latency & throughput. I've documented the available settings for these users.